### PR TITLE
fix: correct critical typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Implimentation
-This document describes the software implimentation.
-Note: The word 'implementation' is misspelled as 'implmentation' here.
+# Project Implementation
+This document describes the software implementation.
+Note: The word 'implementation' has been corrected.
 


### PR DESCRIPTION
- Changed 'implementation' to 'implementation'
- This was causing confusion for users